### PR TITLE
feat(ux): use numeric keyboard on mobile

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -118,6 +118,7 @@
           matInput
           [formControl]="income"
           type="number"
+          inputmode="decimal"
           class="big-input"
           autofocus
         />


### PR DESCRIPTION
Currently on mobile when you edit the income, it shows fullsize alphabetical keyboard, because `inputmode` is not defined. With defined `inputmode` it will show keyboard with only numbers, which is much more convinient on mobile devices.  

## Screenshots  
| As is  |  To be |
| -------- | ------- |
|  ![IMG_0972](https://github.com/user-attachments/assets/18aba129-7a52-498d-8f1c-48282951c672) |  ![IMG_0974](https://github.com/user-attachments/assets/8438bbbf-61a5-4a25-b69c-ca7d6a960c3e)   |