### PR TITLE
fix: retain value of selectedYear on form-field

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,8 +10,8 @@ import { merge } from 'rxjs';
 })
 export class AppComponent implements OnInit {
   title = 'dutch-tax-income-calculator';
-  selectedYear = new FormControl(constants.currentYear);
-  years = constants.years.reverse();
+  selectedYear = new FormControl(constants.currentYear.toString());
+  years = constants.years.reverse().map((year: number) => year.toString());
   hoursAmount = new FormControl(constants.defaultWorkingHours);
   income = new FormControl(60000);
   startFrom = new FormControl<'Year' | 'Month' | 'Week' | 'Day' | 'Hour'> ('Year');


### PR DESCRIPTION
ISSUE:

As demonstrated in the video below, the value `selectedYear` disappears when:
- a new option is selected
- either of the three options checkboxes ("Holiday allowance included", "66 years & older", and "30% ruling") above the field is selected


https://github.com/user-attachments/assets/b6a2ee23-6f8a-493b-9c0c-067b02766370


