### PR TITLE
Add configurable ruling percentage dropdown for the new 27% percentage

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -55,13 +55,20 @@
         </li>
       </ul>
 
-      <div *ngIf="ruling.value" style="display: flex; align-items: center;">
+      <div *ngIf="ruling.value" style="display: flex; align-items: center; gap: 8px;">
         <mat-form-field appearance="fill" style="flex: 1;">
           <mat-label>Ruling Percentage</mat-label>
-          <mat-select [formControl]="rulingPercentage">
-            <mat-option [value]="30">30%</mat-option>
-            <mat-option [value]="27">27%</mat-option>
-          </mat-select>
+          <input
+            matInput
+            type="number"
+            [formControl]="rulingPercentage"
+            min="0"
+            max="30"
+            step="0.1"
+          />
+          <span matSuffix>%</span>
+          <mat-error *ngIf="rulingPercentage.hasError('min')">Value must be at least 0%</mat-error>
+          <mat-error *ngIf="rulingPercentage.hasError('max')">Value must be at most 30%</mat-error>
         </mat-form-field>
       </div>
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -50,10 +50,20 @@
         </li>
         <li>
           <mat-checkbox color="primary" [formControl]="ruling"
-            >30% ruling</mat-checkbox
+            >30% ruling (Expat Scheme)</mat-checkbox
           >
         </li>
       </ul>
+
+      <div *ngIf="ruling.value" style="display: flex; align-items: center;">
+        <mat-form-field appearance="fill" style="flex: 1;">
+          <mat-label>Ruling Percentage</mat-label>
+          <mat-select [formControl]="rulingPercentage">
+            <mat-option [value]="30">30%</mat-option>
+            <mat-option [value]="27">27%</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
 
       <mat-radio-group
         aria-labelledby="ruling-details"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -73,6 +73,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
   startFrom = new FormControl<'Year' | 'Month' | 'Week' | 'Day' | 'Hour'> ('Year');
   ruling = new FormControl(false);
   rulingChoice = new FormControl('normal');
+  rulingPercentage = new FormControl(30);
   allowance = new FormControl(false);
   older = new FormControl(false);
   paycheck!: any;
@@ -262,6 +263,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       queryParams['allowance'] && this.allowance.setValue(queryParams['allowance'] === 'true');
       queryParams['hoursAmount'] && this.hoursAmount.setValue(queryParams['hoursAmount']);
       queryParams['ruling'] && this.ruling.setValue(queryParams['ruling'] === 'true');
+      queryParams['rulingPercentage'] && this.rulingPercentage.setValue(Number(queryParams['rulingPercentage']));
     });
 
 
@@ -273,7 +275,8 @@ export class AppComponent implements OnInit, AfterViewChecked {
       this.allowance.valueChanges,
       this.hoursAmount.valueChanges,
       this.rulingChoice.valueChanges,
-      this.ruling.valueChanges
+      this.ruling.valueChanges,
+      this.rulingPercentage.valueChanges
     ).subscribe((_) => {
       this.updateRouter();
       this.recalculate();
@@ -343,6 +346,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       {
         checked: this.ruling.getRawValue() ?? false,
         choice: this.rulingChoice.getRawValue() ?? 'normal',
+        percentage: this.rulingPercentage.getRawValue() ?? 30,
       } as any
     );
 
@@ -418,6 +422,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       socialSecurity: true,
       hoursAmount: this.hoursAmount.getRawValue(),
       ruling: this.ruling.getRawValue(),
+      rulingPercentage: this.rulingPercentage.getRawValue(),
     };
 
     this.router.navigate([], {

--- a/src/app/ruling/ruling.component.html
+++ b/src/app/ruling/ruling.component.html
@@ -11,5 +11,10 @@
             <b>{{ruling[year].normal | currency:"EUR ": '': '0.0-0'}}</b> ({{year - 1}}: {{ruling[year - 1].normal | currency:"EUR ": '': '0.0-0' }}).
         </li>
         </ul>
+        <h3>Ruling Percentage</h3>
+        <ul>
+            <li>If your ruling decision (beschikking) is dated ≤ 31-12-2023, the ruling is fixed at 30% for the full duration of the ruling</li>
+            <li>Otherwise, the ruling is 30% until 2027, and 27% on 2027 onward</li>
+        </ul>
     </mat-card-content>  
 </mat-card>

--- a/src/app/ruling/ruling.component.html
+++ b/src/app/ruling/ruling.component.html
@@ -2,7 +2,7 @@
     <mat-card-content>
         <h2>About 30% Ruling</h2>
         <p> The salary criteria for the <b>30% ruling</b> as per January {{year}} are as follows:<br></p>
-        <ul> 
+        <ul>
         <li>The salary amount does not matter if working with scientific research.</li>
         <li>The annual taxable salary for an employee with a master’s degree and who is younger than 30 years, must be more than
             <b>{{ruling[year].young | currency:"EUR ": '': '0.0-0'}}</b> ({{year - 1}}: {{ruling[year - 1].young | currency:"EUR ": '': '0.0-0'}}).
@@ -13,8 +13,9 @@
         </ul>
         <h3>Ruling Percentage</h3>
         <ul>
-            <li>If your ruling decision (beschikking) is dated ≤ 31-12-2023, the ruling is fixed at 30% for the full duration of the ruling</li>
-            <li>Otherwise, the ruling is 30% until 2027, and 27% on 2027 onward</li>
+            <li><b>30%</b> Until 2027, or the full duration of the ruling if If your ruling decision (beschikking) is dated ≤ 31-12-2023</li>
+            <li><b>27%</b> From 2027 onward</li>
+            <li><b>Custom</b> Non-standard ruling percentage (0-30%)</li>
         </ul>
-    </mat-card-content>  
+    </mat-card-content>
 </mat-card>


### PR DESCRIPTION
## Summary
Added a configurable ruling percentage dropdown to the 30% ruling section, allowing users to select between 30% and the new 27% based on their ruling.

## Changes
- Added `rulingPercentage` FormControl with query param support
- Added ruling percentage dropdown with options (30%, 27%)
- Updated ruling component documentation to clarify the percentage rules

## Screenshots
<img width="2448" height="1552" alt="image" src="https://github.com/user-attachments/assets/8fe7c571-8375-457b-b81a-744aa7115652" />

## Dependencies
Requires `dutch-tax-income-calculator-npm` NPM package, which includes support for the custom `percentage` parameter in this PR https://github.com/stevermeister/dutch-tax-income-calculator-npm/pull/48
