### PR TITLE
Add support for calculating one-off bonus payments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dutch-tax-income-calculator-frontend",
-  "version": "25.3.1",
+  "version": "26.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dutch-tax-income-calculator-frontend",
-      "version": "25.3.1",
+      "version": "26.1.1",
       "dependencies": {
         "@angular/animations": "^20.3.10",
         "@angular/cdk": "^20.2.12",
@@ -19,7 +19,7 @@
         "@angular/platform-browser-dynamic": "^20.3.10",
         "@angular/router": "^20.3.10",
         "@angular/service-worker": "^20.3.10",
-        "dutch-tax-income-calculator": "^25.3.1",
+        "dutch-tax-income-calculator": "^26.1.1",
         "ngx-cookie-service": "^20.1.1",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
@@ -5299,10 +5299,9 @@
       }
     },
     "node_modules/dutch-tax-income-calculator": {
-      "version": "25.3.1",
-      "resolved": "https://registry.npmjs.org/dutch-tax-income-calculator/-/dutch-tax-income-calculator-25.3.1.tgz",
-      "integrity": "sha512-S0fxFLwvBbFPpRjMgNzjTpGnLjy5p4dKmaP98z1DKGQABP0+QoO5To5Bc9Gd4Kut6hh2H2RBZY/TFWD/dTUACg==",
-      "license": "ISC",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/dutch-tax-income-calculator/-/dutch-tax-income-calculator-26.1.1.tgz",
+      "integrity": "sha512-Ci5O+K05fabz4EyKqDigU660adoWsyagshJNpD9nNVceRjDCtjBKJNTIbMmj1RXj8Tl14DPnuj4thbsf1+OLXw==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -101,6 +101,7 @@
       <ul class="list-style-type-none">
         <li *ngFor="let option of extraOptions">
           <mat-checkbox
+            *ngIf="!option.bonusOnly || bonusEnabled.value"
             color="primary"
             [checked]="option.checked"
             (change)="option.checked = !option.checked; recalculate()"
@@ -136,6 +137,18 @@
         </mat-select>
       </mat-form-field>
     </div>
+
+    <div style="margin-top: 16px;">
+      <mat-checkbox color="primary" [formControl]="bonusEnabled">Include one-off bonus</mat-checkbox>
+    </div>
+
+    <div *ngIf="bonusEnabled.value" style="margin-top: 12px;">
+      <mat-form-field>
+        <mat-label>Gross bonus amount</mat-label>
+        <input matInput [formControl]="bonusGross" type="number" inputmode="decimal" min="0" />
+        <mat-error *ngIf="bonusGross.hasError('min')">Bonus cannot be negative</mat-error>
+      </mat-form-field>
+    </div>
   </mat-card>
 
   <mat-card>
@@ -158,7 +171,7 @@
               *matCellDef="let element"
               class="report-value"
               [class.report-value-negative]="element.value < 0"
-              [class.big-output]="element.name === 'Month Net Income'"
+              [class.big-output]="element.name.includes('Month Net Income') || element.name === 'Net Bonus (take-home)' || element.name === 'Total Net (Salary + Bonus)'"
               [class.has-overflow]="cellsWithOverflow.has(element.name)"
               [attr.data-cell-id]="element.name"
               (click)="showTooltip(element.name, element, $event)"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewChecked } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { constants, SalaryPaycheck } from 'dutch-tax-income-calculator';
 import { merge, Subject } from 'rxjs';
@@ -75,16 +75,17 @@ export class AppComponent implements OnInit, AfterViewChecked {
   rulingChoice = new FormControl('normal');
   allowance = new FormControl(false);
   older = new FormControl(false);
+  bonusEnabled = new FormControl(false);
+  bonusGross = new FormControl(0, [Validators.min(0)]);
   paycheck!: any;
 
-  extraOptions = [
-    {
-      name: 'grossAllowance',
-      sign: '',
-      title: 'Year Gross Holiday Allowance',
-      label: 'Gross Holiday Allowance per year',
-      checked: false,
-    },
+
+  bonusValues: Record<string, number> = {};
+
+  extraOptions: {
+    name: string; sign: string; title: string; label: string;
+    checked: boolean; bonusOnly?: boolean;
+  }[] = [
     {
       name: 'grossYear',
       sign: '',
@@ -118,6 +119,13 @@ export class AppComponent implements OnInit, AfterViewChecked {
       sign: '',
       title: 'Hour Gross Income',
       label: 'Gross Income per hour',
+      checked: false,
+    },
+    {
+      name: 'grossAllowance',
+      sign: '',
+      title: 'Year Gross Holiday Allowance',
+      label: 'Gross Holiday Allowance per year',
       checked: false,
     },
     {
@@ -229,6 +237,46 @@ export class AppComponent implements OnInit, AfterViewChecked {
       label: 'Hourly Net Income',
       checked: false,
     },
+    {
+      name: 'grossBonus',
+      sign: '',
+      title: 'Gross Bonus',
+      label: 'Gross one-off bonus payment',
+      checked: true,
+      bonusOnly: true,
+    },
+    {
+      name: 'bonusTax',
+      sign: '-',
+      title: 'Tax on Bonus',
+      label: 'Marginal tax deducted from bonus',
+      checked: false,
+      bonusOnly: true,
+    },
+    {
+      name: 'netBonus',
+      sign: '',
+      title: 'Net Bonus (take-home)',
+      label: 'Bonus payment after tax',
+      checked: true,
+      bonusOnly: true,
+    },
+    {
+      name: 'totalGross',
+      sign: '',
+      title: 'Total Gross (Salary + Bonus)',
+      label: 'Combined annual gross income including bonus',
+      checked: false,
+      bonusOnly: true,
+    },
+    {
+      name: 'totalNet',
+      sign: '',
+      title: 'Total Net (Salary + Bonus)',
+      label: 'Combined annual net income including bonus',
+      checked: true,
+      bonusOnly: true,
+    },
   ];
 
   dataSource!: { name: string; value: number }[];
@@ -262,6 +310,8 @@ export class AppComponent implements OnInit, AfterViewChecked {
       queryParams['allowance'] && this.allowance.setValue(queryParams['allowance'] === 'true');
       queryParams['hoursAmount'] && this.hoursAmount.setValue(queryParams['hoursAmount']);
       queryParams['ruling'] && this.ruling.setValue(queryParams['ruling'] === 'true');
+      queryParams['bonusEnabled'] && this.bonusEnabled.setValue(queryParams['bonusEnabled'] === 'true');
+      queryParams['bonusGross'] && this.bonusGross.setValue(Number(queryParams['bonusGross']));
     });
 
 
@@ -273,10 +323,20 @@ export class AppComponent implements OnInit, AfterViewChecked {
       this.allowance.valueChanges,
       this.hoursAmount.valueChanges,
       this.rulingChoice.valueChanges,
-      this.ruling.valueChanges
+      this.ruling.valueChanges,
+      this.bonusEnabled.valueChanges,
+      this.bonusGross.valueChanges
     ).subscribe((_) => {
       this.updateRouter();
       this.recalculate();
+    });
+
+    this.bonusEnabled.valueChanges.subscribe((enabled) => {
+      if (enabled && (this.bonusGross.getRawValue() ?? 0) <= 0) {
+        this.recalculate();
+        const defaultBonus = Math.round(this.paycheck.grossYear * 0.1);
+        this.bonusGross.setValue(defaultBonus, { emitEvent: true });
+      }
     });
   }
 
@@ -346,13 +406,63 @@ export class AppComponent implements OnInit, AfterViewChecked {
       } as any
     );
 
+    // Bonus calculation: marginal tax approach
+    this.bonusValues = {};
+    const bonusOn = this.bonusEnabled.getRawValue();
+    if (bonusOn) {
+      const grossSalaryYear = this.paycheck.grossYear;
+      const grossBonus = Math.max(0, this.bonusGross.getRawValue() ?? 0);
+
+      if (grossBonus > 0) {
+        const year = +(this.selectedYear.getRawValue() ?? constants.currentYear);
+        const rulingOpts = {
+          checked: this.ruling.getRawValue() ?? false,
+          choice: this.rulingChoice.getRawValue() ?? 'normal',
+        } as any;
+
+        const salaryPlusBonusPaycheck = new SalaryPaycheck(
+          { ...salary, income: grossSalaryYear + grossBonus },
+          'Year', year, rulingOpts
+        );
+
+        const salaryOnlyPaycheck = new SalaryPaycheck(
+          { ...salary, income: grossSalaryYear },
+          'Year', year, rulingOpts
+        );
+
+        // incomeTax is negative (it's a deduction), so taxOnBonus will be negative
+        const taxOnBonus = salaryPlusBonusPaycheck.incomeTax - salaryOnlyPaycheck.incomeTax;
+        const netBonus = grossBonus + taxOnBonus;
+
+        this.bonusValues = {
+          grossBonus: Math.round(grossBonus * 100) / 100,
+          bonusTax: Math.round(taxOnBonus * 100) / 100,
+          netBonus: Math.round(netBonus * 100) / 100,
+          totalGross: Math.round((grossSalaryYear + grossBonus) * 100) / 100,
+          totalNet: Math.round((this.paycheck.netYear + netBonus) * 100) / 100,
+        };
+      }
+    }
+
+    const salaryDisambiguate = new Set([
+      'grossYear', 'grossMonth', 'grossWeek', 'grossDay', 'grossHour',
+      'netYear', 'netMonth', 'netWeek', 'netDay', 'netHour',
+      'taxableYear', 'incomeTax', 'incomeTaxMonth',
+    ]);
+
     this.dataSource = this.extraOptions
-      .filter((option) => option.checked)
-      .map((option) => ({
-        name: option.title,
-        value: this.paycheck[option.name],
-      }));
-    
+      .filter((option) => {
+        if (option.bonusOnly && !bonusOn) return false;
+        return option.checked;
+      })
+      .map((option) => {
+        const suffix = bonusOn && salaryDisambiguate.has(option.name) ? ' (salary)' : '';
+        return {
+          name: option.title + suffix,
+          value: option.bonusOnly ? this.bonusValues[option.name] : this.paycheck[option.name],
+        };
+      })
+      .filter((row) => row.value !== undefined);
 
     this.cellsWithOverflow.clear();
   }
@@ -409,7 +519,8 @@ export class AppComponent implements OnInit, AfterViewChecked {
   }
 
   updateRouter() {
-    const params = {
+    const bonusOn = this.bonusEnabled.getRawValue();
+    const params: Record<string, any> = {
       income: this.income.getRawValue(),
       startFrom: this.startFrom.getRawValue(),
       selectedYear: this.selectedYear.getRawValue(),
@@ -418,6 +529,8 @@ export class AppComponent implements OnInit, AfterViewChecked {
       socialSecurity: true,
       hoursAmount: this.hoursAmount.getRawValue(),
       ruling: this.ruling.getRawValue(),
+      bonusEnabled: bonusOn || null,
+      bonusGross: bonusOn ? this.bonusGross.getRawValue() : null,
     };
 
     this.router.navigate([], {


### PR DESCRIPTION
Adds an optional one-off bonus calculation. 

- Enter a gross bonus amount, see the net take-home after marginal tax. 
- Bonus fields integrate into the existing results table and sidebar options. 
- Labels disambiguate with "(salary)" when bonus is active.