### PR TITLE
fix: bump calculator package to 26.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "^20.3.10",
     "@angular/router": "^20.3.10",
     "@angular/service-worker": "^20.3.10",
-    "dutch-tax-income-calculator": "26.1.2",
+    "dutch-tax-income-calculator": "26.1.3",
     "ngx-cookie-service": "^20.1.1",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
## Summary
- Bumps `dutch-tax-income-calculator` from 26.1.2 to 26.1.3
- Fixes the bug where the "holiday allowance included" checkbox had **no effect** when the 30% ruling was active ([stevermeister/dutch-tax-income-calculator-npm#53](https://github.com/stevermeister/dutch-tax-income-calculator-npm/issues/53))

## What was wrong
In 26.1.2, when the 30% ruling is active, `taxableYear` is overwritten by `grossYear - reimbursement`, completely ignoring `grossAllowance`. This makes the allowance checkbox a no-op — all tax and net income fields are identical regardless of the toggle.

## What 26.1.3 fixes
Adds 8% gross inflation logic when `allowance=false` + ruling is checked, so the two checkbox states produce correctly different results.

## Test plan
- [ ] Verify toggling "holiday allowance included" with 30% ruling now changes netYear/netMonth
- [ ] Verify equivalent salaries (e.g. 5000/mo without holiday vs 5400/mo with holiday) produce identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)