### PR TITLE
feat: add holiday payout toggle (monthly vs May)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,11 @@
             >Holiday allowance included</mat-checkbox
           >
         </li>
+        <li *ngIf="allowance.value">
+          <mat-checkbox color="primary" [formControl]="holidayPayoutMay"
+            >Holiday payout in May</mat-checkbox
+          >
+        </li>
         <li>
           <mat-checkbox color="primary" [formControl]="older"
             >66 years & older</mat-checkbox

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -74,6 +74,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
   ruling = new FormControl(false);
   rulingChoice = new FormControl('normal');
   allowance = new FormControl(false);
+  holidayPayoutMay = new FormControl(false);
   older = new FormControl(false);
   paycheck!: any;
 
@@ -262,6 +263,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       queryParams['allowance'] && this.allowance.setValue(queryParams['allowance'] === 'true');
       queryParams['hoursAmount'] && this.hoursAmount.setValue(queryParams['hoursAmount']);
       queryParams['ruling'] && this.ruling.setValue(queryParams['ruling'] === 'true');
+      queryParams['holidayPayoutMay'] && this.holidayPayoutMay.setValue(queryParams['holidayPayoutMay'] === 'true');
     });
 
 
@@ -271,6 +273,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       this.selectedYear.valueChanges,
       this.older.valueChanges,
       this.allowance.valueChanges,
+      this.holidayPayoutMay.valueChanges,
       this.hoursAmount.valueChanges,
       this.rulingChoice.valueChanges,
       this.ruling.valueChanges
@@ -346,12 +349,35 @@ export class AppComponent implements OnInit, AfterViewChecked {
       } as any
     );
 
+    const mayPayout = this.holidayPayoutMay.getRawValue() && this.allowance.getRawValue();
+    const netAllowance = this.paycheck.netAllowance || 0;
+
     this.dataSource = this.extraOptions
       .filter((option) => option.checked)
-      .map((option) => ({
-        name: option.title,
-        value: this.paycheck[option.name],
-      }));
+      .map((option) => {
+        let value = this.paycheck[option.name];
+
+        // When May payout is selected, exclude holiday from period amounts
+        if (mayPayout && netAllowance > 0) {
+          const netYearWithoutHoliday = this.paycheck.netYear - netAllowance;
+          switch (option.name) {
+            case 'netMonth':
+              value = netYearWithoutHoliday / 12;
+              break;
+            case 'netWeek':
+              value = netYearWithoutHoliday / 52;
+              break;
+            case 'netDay':
+              value = netYearWithoutHoliday / 255;
+              break;
+            case 'netHour':
+              value = netYearWithoutHoliday / (52 * (this.hoursAmount.getRawValue() || 40));
+              break;
+          }
+        }
+
+        return { name: option.title, value };
+      });
     
 
     this.cellsWithOverflow.clear();
@@ -418,6 +444,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
       socialSecurity: true,
       hoursAmount: this.hoursAmount.getRawValue(),
       ruling: this.ruling.getRawValue(),
+      holidayPayoutMay: this.holidayPayoutMay.getRawValue(),
     };
 
     this.router.navigate([], {


### PR DESCRIPTION
## Summary
- Adds a "Holiday payout in May" checkbox that appears when "Holiday allowance included" is checked
- When enabled, net period amounts (month/week/day/hour) exclude the holiday component, showing what the user actually receives each period
- The holiday amount is available via the existing "Year Net Holiday Allowance" extra option
- Persisted in URL query params for shareability

This reflects the common Dutch setup where vakantiegeld is either:
- Spread across monthly paychecks (default)
- Paid as a lump sum in May (new toggle)

Closes #28

## Test plan
- [ ] Check "Holiday allowance included" → "Holiday payout in May" sub-checkbox appears
- [ ] With May payout on: net month should be lower (holiday excluded)
- [ ] With May payout off: net month includes holiday (current behavior)
- [ ] Uncheck "Holiday allowance included" → sub-checkbox disappears
- [ ] Toggle state persists in URL query params
- [ ] Works correctly with and without 30% ruling

🤖 Generated with [Claude Code](https://claude.com/claude-code)