### PR TITLE
feat(seo): add canonical tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">
+  <link rel="canonical" href="https://thetax.nl/">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- Adds `<link rel="canonical" href="https://thetax.nl/">` to `src/index.html`
- Tells Google that all query-param URL variants (`?year=...&salary=...`) are duplicates of the canonical root URL
- This single line addresses the largest cluster (~62 of 139) of deindexed pages reported in Search Console

## Why this works
The calculator is a single-page app — query params are UI state, not distinct content. Without a canonical tag, Googlebot treats every unique URL variant as a separate page to index, leading to the "Crawled - currently not indexed" and "Duplicate without canonical" signals in Search Console.

## Risk
Minimal — read-only hint to crawlers, no runtime code change, no build impact.

## Test plan
- [ ] Build succeeds (`ng build`)
- [ ] `curl https://thetax.nl/ | grep canonical` returns the tag after deploy
- [ ] Google Search Console → URL Inspection → `https://thetax.nl/` shows canonical as self-referencing after next crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)