### PR TITLE
feat(seo): add static meta tags and JSON-LD

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,16 +11,48 @@
     gtag('config', 'UA-12112718-8');
   </script>
   <meta charset="utf-8">
-  <title>Dutch Income Tax Calculator</title>
+  <title>Dutch Income Tax Calculator 2026 — IB Aangifte 2025 | thetax.nl</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">	
+  <meta name="description" content="Calculate your Dutch income tax for tax years 2025 and 2026. Includes 30% ruling, box 1/2/3, heffingskortingen — free, no signup, no ads.">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Dutch Income Tax Calculator 2026">
+  <meta property="og:description" content="Calculate your Dutch income tax for 2025 and 2026. Includes 30% ruling, box 1/2/3, heffingskortingen — free, no signup.">
+  <meta property="og:url" content="https://thetax.nl/">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Dutch Income Tax Calculator 2026">
+  <meta name="twitter:description" content="Calculate your Dutch income tax for 2025 and 2026. Includes 30% ruling, box 1/2/3, heffingskortingen — free, no signup.">
+
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&amp;display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">
   <link rel="canonical" href="https://thetax.nl/">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Dutch Income Tax Calculator",
+    "url": "https://thetax.nl/",
+    "description": "Calculate your Dutch income tax for tax years 2025 and 2026. Includes 30% ruling, box 1/2/3, heffingskortingen — free, no signup, no ads.",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Any",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "inLanguage": "en"
+  }
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- Replace bare `<title>` with `Dutch Income Tax Calculator 2026 — IB Aangifte 2025 | thetax.nl` (keyword-rich, bilingual signal)
- Add `<meta name="description">` for SERP snippet
- Add Open Graph tags (`og:type`, `og:title`, `og:description` ~120 chars, `og:url`, `og:locale`) — no `og:image` yet, image asset comes in a later PR
- Add Twitter Card (`twitter:card=summary`, title, description) — no `twitter:image` yet
- Add `<script type="application/ld+json">` WebApplication schema with `name`, `url`, `applicationCategory=FinanceApplication`, `operatingSystem=Any`, free `offers`, `inLanguage=en`

## Notes
- `og:description` is trimmed to ~120 chars as specified (full description kept in `meta description`)
- `twitter:card=summary` (not `summary_large_image`) because no image asset exists yet
- No runtime code change — all static `<head>` markup

## Test plan
- [ ] Build succeeds (`ng build`)
- [ ] View source shows all new tags after deploy
- [ ] [Rich Results Test](https://search.google.com/test/rich-results) on `https://thetax.nl/` detects WebApplication schema
- [ ] Social preview (LinkedIn/Slack unfurl) shows title + description

🤖 Generated with [Claude Code](https://claude.com/claude-code)