### PR TITLE
chore(analytics): migrate to GA4 with UA overlap

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,12 +2,14 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-12112718-8"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8CJ1CQ0KY"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
+    gtag('config', 'G-N8CJ1CQ0KY');
+    // TODO: remove UA config after verifying GA4 native data
     gtag('config', 'UA-12112718-8');
   </script>
   <meta charset="utf-8">


### PR DESCRIPTION
## Summary
- Switches the `gtag.js` script src from `UA-12112718-8` to `G-N8CJ1CQ0KY` (GA4 measurement ID)
- Adds `gtag('config', 'G-N8CJ1CQ0KY')` as the primary config call
- Keeps `gtag('config', 'UA-12112718-8')` as a parallel config for ~2 weeks so UA and GA4 data can be verified side-by-side — marked with a `TODO: remove` comment for the follow-up PR

## How it works
A single `gtag.js` script loaded with the GA4 ID handles both config calls. No second `<script>` tag needed — this is the standard dual-tagging pattern Google recommends during UA → GA4 migration.

## Test plan
- [ ] Build succeeds (`ng build`)
- [ ] After deploy: open DevTools → Network, confirm `collect` requests go to `google-analytics.com/g/collect` (GA4 endpoint)
- [ ] GA4 property `G-N8CJ1CQ0KY` shows realtime hits in Google Analytics within minutes of deploy
- [ ] UA property `UA-12112718-8` continues to show hits in parallel during the overlap window
- [ ] Remove the UA config line (~2 weeks after confirming GA4 data looks correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)