### PR TITLE
fix(routing): sanitize URL query params

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -484,10 +484,14 @@ export class AppComponent implements OnInit, AfterViewChecked, OnDestroy {
       holidayPayoutMay: this.holidayPayoutMay.getRawValue(),
     };
 
+    // Map invalid values to null so Angular Router removes them from the URL.
+    // Filtering them out entirely would leave stale values in the URL when
+    // using queryParamsHandling: 'merge'.
     const params = Object.fromEntries(
-      Object.entries(raw).filter(([, v]) =>
-        v !== null && v !== undefined && v !== '' && !Number.isNaN(v)
-      )
+      Object.entries(raw).map(([k, v]) => [
+        k,
+        v === null || v === undefined || v === '' || Number.isNaN(v) ? null : v,
+      ])
     );
 
     this.router.navigate([], {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -472,7 +472,7 @@ export class AppComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   updateRouter() {
-    const params = {
+    const raw: Record<string, unknown> = {
       income: this.income.getRawValue(),
       startFrom: this.startFrom.getRawValue(),
       selectedYear: this.selectedYear.getRawValue(),
@@ -484,10 +484,17 @@ export class AppComponent implements OnInit, AfterViewChecked, OnDestroy {
       holidayPayoutMay: this.holidayPayoutMay.getRawValue(),
     };
 
+    const params = Object.fromEntries(
+      Object.entries(raw).filter(([, v]) =>
+        v !== null && v !== undefined && v !== '' && !Number.isNaN(v)
+      )
+    );
+
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: params,
-      queryParamsHandling: 'merge', // remove to replace all query params by provided
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Collects raw form values into a `raw` object, then strips any entry where the value is `null`, `undefined`, `''`, or `NaN` before passing to `router.navigate()`
- Adds `replaceUrl: true` to the navigate options so every keystroke/toggle replaces the current history entry instead of pushing a new one

## Why
Search Console crawl logs showed URLs like `?salary=NaN&year=2026` being indexed — these arise when the income field is cleared and `getRawValue()` returns `NaN`. Filtering before writing prevents those variants from ever reaching the URL bar.

`replaceUrl: true` reduces future backlinks to garbage URL variants and stops the browser history from accumulating an entry per keystroke (typing a salary like `75000` used to push 5 history entries).

## Test plan
- [ ] Build succeeds (`ng build`)
- [ ] Clear the income field — URL should not contain `income=NaN`
- [ ] Type a salary — back button returns to the page you came from, not a previous salary value
- [ ] Reload with a valid URL like `/?income=70000&year=2026` — values restore correctly (read path unchanged)
- [ ] Reload with `/?income=NaN` — income field falls back to default (NaN filtered on write; read path already guards with `&&`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)