### PR TITLE
fix(seo): correct title and move h1 to HTML shell

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <button mat-icon-button aria-label="menu icon" (click)="drawer.toggle()">
     <mat-icon>menu</mat-icon>
   </button>
-  <h1 title="makes your work easy" class="toolbar-title">Dutch Income Tax Calculator 2026</h1>
+  <span title="makes your work easy" class="toolbar-title">Dutch Income Tax Calculator 2026</span>
 
   <span class="spacer"></span>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,14 +12,6 @@ import { SwUpdate } from '@angular/service-worker';
     selector: 'app-root',
     templateUrl: './app.component.html',
     styles: [`
-    h1.toolbar-title {
-      font-size: inherit;
-      font-weight: inherit;
-      margin: 0;
-      padding: 0;
-      line-height: inherit;
-    }
-
     .output-results-table {
       width: 600px;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -57,7 +57,9 @@
   </script>
 </head>
 <body>
-  <app-root></app-root>
+  <app-root>
+    <h1>Dutch Income Tax Calculator 2026</h1>
+  </app-root>
 
   <noscript>Please enable JavaScript to continue using this application.</noscript>
 </body>


### PR DESCRIPTION
## Summary

### Fix 1 — Title
The `<title>` tag already contains plain text `thetax.nl` (no markdown syntax present in the file), so no change needed there.

### Fix 2 — h1 in initial HTML response
- Adds `<h1>Dutch Income Tax Calculator 2026</h1>` **inside `<app-root>`** in `src/index.html` so it is present in the raw HTTP response, before any JavaScript executes
- Reverts the toolbar element in `app.component.html` from `<h1>` back to `<span>` (the shell h1 now fulfils the heading role)
- Removes the now-unused `h1.toolbar-title` CSS reset from `app.component.ts`

## Why this matters
The h1 added in PR 3 lived inside the Angular component template — it only appears in the DOM **after** the JS bundle downloads, parses, and Angular bootstraps. Non-JS crawlers (Bing, most social bots, preview renderers) and first-paint performance audits never see it. Placing it inside `<app-root>` means it ships in the initial HTML payload. Angular replaces `<app-root>` content on bootstrap, so users only see the shell h1 for the brief loading window — no layout issue.

## Verification
After deploy:
```
curl -s https://thetax.nl/ | grep -i '<h1'
# expected: <h1>Dutch Income Tax Calculator 2026</h1>
```

## Test plan
- [ ] Build succeeds (`ng build`)
- [ ] `curl` on the deployed URL returns the `<h1>` in the HTML source
- [ ] Browser: toolbar still displays "Dutch Income Tax Calculator 2026" (as a `<span>`, visually unchanged)
- [ ] Lighthouse / axe: no "page must contain a level-one heading" violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)